### PR TITLE
Support for running build command from a task

### DIFF
--- a/src/contributions/commands/isURI.ts
+++ b/src/contributions/commands/isURI.ts
@@ -1,0 +1,10 @@
+import { URL } from "node:url";
+
+export function isURI(something: any): boolean {
+  try {
+    new URL(something);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}

--- a/src/contributions/commands/workspace.ts
+++ b/src/contributions/commands/workspace.ts
@@ -4,9 +4,13 @@ import { runBuild } from "#building/build-runner";
 import * as stbls from "#stbls/stbl-commands";
 import { convertFolderToProject } from "#workspace/folder-to-project";
 import S4TKWorkspaceManager from "#workspace/workspace-manager";
+import { isURI } from "./isURI";
 
 export default function registerWorkspaceCommands() {
   vscode.commands.registerCommand(S4TKCommand.workspace.build, async (uri?: vscode.Uri) => {
+    if (!isURI(uri)) {
+      uri = undefined;
+    }
     const workspace = await S4TKWorkspaceManager.chooseWorkspace(uri);
     if (workspace) runBuild(workspace, "build", "Build");
   });


### PR DESCRIPTION
This adds support for running the build command as a task. This has a use case for a build pipeline with multiple steps (i.e. also compiling Python scripts to a ts4scripts file).

**tasks.json:**

```json
{
  // See https://go.microsoft.com/fwlink/?LinkId=733558
  // for the documentation about the tasks.json format
  "version": "2.0.0",
  "tasks": [
    {
      "label": "build package",
      "command": "${command:s4tk.workspace.build}"
    },
    {
      "label": "build scripts",
      "type": "shell",
      "command": "python ../sims4-mod-development-tools/compile.py"
    },
    {
      "label": "build",
      "dependsOn": ["build package", "build scripts"],
      "problemMatcher": [],
      "group": {
        "kind": "build",
        "isDefault": true
      }
    },
    {
      "label": "deploy",
      "type": "shell",
      "command": "./deploy.sh"
    },
    {
      "label": "build and deploy",
      "dependsOrder": "sequence",
      "dependsOn": ["build", "deploy"]
    }
  ]
}
```

Before the changes of this PR, it seems that when the command was run as a task like the task "build package" from the tasks.json above, the extension received some JSON object as first argument which was not a URI. With the added URI check from this PR, the command works in both cases, running from command palette or via a task.